### PR TITLE
split apart Inertia and InertiaConfig

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,38 @@
+use std::sync::Arc;
+
+struct Inner {
+    version: Option<String>,
+    layout: Box<dyn Fn(String) -> String + Send + Sync>,
+}
+
+#[derive(Clone)]
+pub struct InertiaConfig {
+    inner: Arc<Inner>,
+}
+
+impl InertiaConfig {
+    /// Constructs a new InertiaConfig object.
+    ///
+    /// `layout` provides information about how to render the initial
+    /// page load. See the [crate::vite] module for an implementation
+    /// of this for vite.
+    pub fn new(
+        version: Option<String>,
+        layout: Box<dyn Fn(String) -> String + Send + Sync>,
+    ) -> InertiaConfig {
+        let inner = Inner { version, layout };
+        InertiaConfig {
+            inner: Arc::new(inner),
+        }
+    }
+
+    /// Returns a cloned optional version string.
+    pub fn version(&self) -> Option<String> {
+        self.inner.version.clone()
+    }
+
+    /// Returns a reference to the layout function.
+    pub fn layout(&self) -> &(dyn Fn(String) -> String + Send + Sync) {
+        &self.inner.layout
+    }
+}

--- a/src/vite.rs
+++ b/src/vite.rs
@@ -14,19 +14,19 @@
 //!         .unwrap()
 //!         .lang("en")
 //!         .title("My app")
-//!         .into_inertia()
+//!         .into_config()
 //! } else {
 //!     vite::Development::default()
 //!         .port(5173)
 //!         .main("src/main.ts")
 //!         .lang("en")
 //!         .title("My app")
-//!         .into_inertia()
+//!         .into_config()
 //! };
 //! ```
 //!
 //! [vitejs]: https://vitejs.dev
-use crate::Inertia;
+use crate::config::InertiaConfig;
 use hex::encode;
 use maud::{html, PreEscaped};
 use serde::Deserialize;
@@ -72,7 +72,7 @@ impl Development {
         self
     }
 
-    pub fn into_inertia(self) -> Inertia {
+    pub fn into_config(self) -> InertiaConfig {
         let layout = Box::new(move |props| {
             let vite_src = format!("http://localhost:{}/@vite/client", self.port);
             let main_src = format!("http://localhost:{}/{}", self.port, self.main);
@@ -85,6 +85,7 @@ impl Development {
                         script type="module" src=(vite_src) {}
                         script type="module" src=(main_src) {}
                     }
+
                     body {
                         div #app data-page=(props) {}
                     }
@@ -92,7 +93,7 @@ impl Development {
             }
             .into_string()
         });
-        Inertia::new(None, layout)
+        InertiaConfig::new(None, layout)
     }
 }
 
@@ -148,7 +149,7 @@ impl Production {
         self
     }
 
-    pub fn into_inertia(self) -> Inertia {
+    pub fn into_config(self) -> InertiaConfig {
         let layout = Box::new(move |props| {
             let css = self.css.clone().unwrap_or("".to_string());
             html! {
@@ -167,7 +168,7 @@ impl Production {
             }
             .into_string()
         });
-        Inertia::new(Some(self.version), layout)
+        InertiaConfig::new(Some(self.version), layout)
     }
 }
 


### PR DESCRIPTION
This lets us get rid of the awkward handling of the `Request`, which
we needed to wrap in an option on `Inertia` because it was doubling as
a config object (with no request).

I don't love the name "InertiaConfig" but keeping it more explicit for
now.