### PR TITLE
add `Props` trait to allow for partial reload handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- A new `Props` trait is added for use with `Inertia::render`. Objects
+  that implement `Props` know how to serialize themselves to json and
+  are passed information about "partial" Inertia reloads to exclude
+  certain fields. This trait can hopefully eventually be used to
+  implement a derive macro for prop types that support things like
+  lazily evaluated props.
+
 ## [0.3.0] 2024-02-12
 
 - Split configuration to a new `InertiaConfig` struct

--- a/src/partial.rs
+++ b/src/partial.rs
@@ -1,0 +1,11 @@
+/// Partial reload data.
+///
+/// Clients can request a subset of the props if a page component is
+/// being refreshed. They must also include a desired component -- the
+/// server may respond with a different end component, which will
+/// include a full response.
+#[derive(Clone, Debug)]
+pub struct Partial {
+    pub props: Vec<String>,
+    pub component: String,
+}

--- a/src/props.rs
+++ b/src/props.rs
@@ -1,0 +1,36 @@
+//! The [Props] trait describes objects that can be used as Inertia
+//! props, and allows for handling around [inertia partial
+//! reloads](partial-reloads). See the trait documentation for more.
+//!
+//! [partial-reloads]: https://inertiajs.com/the-protocol#partial-reloads
+
+use serde::Serialize;
+use serde_json::Value;
+use std::error::Error;
+
+use crate::partial::Partial;
+
+/// Objects that can be used as Inertia props.
+pub trait Props {
+    /// Serialize to json, given data about partial reloads.
+    ///
+    /// This method is called when rendering Inertia responses. The
+    /// [Partial] object is parsed from the request. Implementations
+    /// should return all fields requested in the `props` field. More
+    /// information is available in the [inertia docs].
+    ///
+    /// [inertia docs]: https://inertiajs.com/the-protocol#partial-reloads
+    fn serialize(self, partial: Option<&Partial>) -> Result<Value, impl Error>;
+}
+
+/// A naive, blanket implementation for all types that implement
+/// Serde's [serialize](serde::Serialize). By default, there is no
+/// logic around partial handling; the object is just serialized.
+impl<T> Props for T
+where
+    T: Serialize,
+{
+    fn serialize(self, _: Option<&Partial>) -> Result<Value, impl Error> {
+        serde_json::to_value(self)
+    }
+}

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,18 +1,7 @@
+use crate::partial::Partial;
 use async_trait::async_trait;
 use axum::extract::FromRequestParts;
 use http::{request::Parts, HeaderMap, HeaderValue, StatusCode};
-
-/// Partial reload data.
-///
-/// Clients can request a subset of the props if a page component is
-/// being refreshed. They must also include a desired component -- the
-/// server may respond with a different end component, which will
-/// include a full response.
-#[derive(Clone, Debug)]
-pub(crate) struct Partial {
-    pub(crate) props: Vec<String>,
-    pub(crate) component: String,
-}
 
 /// Inertia-related information in the request.
 ///

--- a/src/request.rs
+++ b/src/request.rs
@@ -53,7 +53,7 @@ where
             .get("X-Inertia-Partial-Data")
             .map(|s| s.to_str().map(|s| s.to_string()))
             .transpose()
-            .map(|s| s.map(|s| s.split(",").map(|s| s.to_owned()).collect::<Vec<_>>()))
+            .map(|s| s.map(|s| s.split(',').map(|s| s.to_owned()).collect::<Vec<_>>()))
             .map_err(|_err| (StatusCode::BAD_REQUEST, HeaderMap::new()))?;
         let partial_component = parts
             .headers

--- a/src/request.rs
+++ b/src/request.rs
@@ -2,6 +2,18 @@ use async_trait::async_trait;
 use axum::extract::FromRequestParts;
 use http::{request::Parts, HeaderMap, HeaderValue, StatusCode};
 
+/// Partial reload data.
+///
+/// Clients can request a subset of the props if a page component is
+/// being refreshed. They must also include a desired component -- the
+/// server may respond with a different end component, which will
+/// include a full response.
+#[derive(Clone, Debug)]
+pub(crate) struct Partial {
+    pub(crate) props: Vec<String>,
+    pub(crate) component: String,
+}
+
 /// Inertia-related information in the request.
 ///
 /// See more info here: https://inertiajs.com/the-protocol.
@@ -10,6 +22,7 @@ pub(crate) struct Request {
     pub(crate) is_xhr: bool,
     pub(crate) version: Option<String>,
     pub(crate) url: String,
+    pub(crate) partial: Option<Partial>,
 }
 
 impl Request {
@@ -19,6 +32,7 @@ impl Request {
             is_xhr: true,
             version: None,
             url: "/foo/bar".to_string(),
+            partial: None,
         }
     }
 }
@@ -45,71 +59,180 @@ where
             .map(|s| s.to_str().map(|s| s.to_string()))
             .transpose()
             .map_err(|_err| (StatusCode::BAD_REQUEST, HeaderMap::new()))?;
+        let partial_data = parts
+            .headers
+            .get("X-Inertia-Partial-Data")
+            .map(|s| s.to_str().map(|s| s.to_string()))
+            .transpose()
+            .map(|s| s.map(|s| s.split(",").map(|s| s.to_owned()).collect::<Vec<_>>()))
+            .map_err(|_err| (StatusCode::BAD_REQUEST, HeaderMap::new()))?;
+        let partial_component = parts
+            .headers
+            .get("X-Inertia-Partial-Component")
+            .map(|s| s.to_str().map(|s| s.to_string()))
+            .transpose()
+            .map_err(|_err| (StatusCode::BAD_REQUEST, HeaderMap::new()))?;
+        // TODO: trace warning if we have one of data/component without the other
+        // TODO: should this enforce is_xhr is true?
+        let partial = match (partial_data, partial_component) {
+            (Some(props), Some(component)) => Some(Partial { props, component }),
+            _ => None,
+        };
+
         Ok(Request {
             is_xhr,
             version,
             url,
+            partial,
         })
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::net::SocketAddr;
+
     use super::*;
     use axum::{self, routing::get, Router};
     use reqwest::StatusCode;
     use tokio::net::TcpListener;
+    use tokio::task::JoinHandle;
 
-    #[tokio::test]
-    async fn it_extracts_inertia_request_info() {
-        async fn handler_expect_inertia(req: Request) {
-            assert!(req.is_xhr);
-            assert_eq!(req.version, Some("required".to_string()))
-        }
-        async fn handler_expect_not_inertia(req: Request) {
-            assert!(!req.is_xhr);
-            assert_eq!(req.version, Some("not-required".to_string()))
-        }
-        async fn handler_expect_no_version(req: Request) {
-            assert_eq!(req.version, None)
-        }
-
-        let app = Router::new()
-            .route("/expect_inertia", get(handler_expect_inertia))
-            .route("/expect_not_inertia", get(handler_expect_not_inertia))
-            .route("/expect_no_version", get(handler_expect_no_version));
-
+    async fn spawn_test_app(app: Router) -> (JoinHandle<()>, SocketAddr) {
         let listener = TcpListener::bind("127.0.0.1:0")
             .await
             .expect("Could not bind ephemeral socket");
         let addr = listener.local_addr().unwrap();
 
-        tokio::spawn(async move {
-            axum::serve(listener, app).await.expect("server error");
-        });
+        (
+            tokio::spawn(async move {
+                axum::serve(listener, app).await.expect("server error");
+            }),
+            addr,
+        )
+    }
+
+    #[tokio::test]
+    async fn it_extracts_inertia_xhr() {
+        async fn handler(req: Request) {
+            assert!(req.is_xhr);
+        }
+        let app = Router::new().route("/test", get(handler));
+        let (_, addr) = spawn_test_app(app).await;
+        let client = reqwest::Client::new();
+
+        let res = client
+            .get(format!("http://{}/test", &addr))
+            .header("X-Inertia", "true")
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn it_extracts_a_false_value_for_x_inertia() {
+        async fn handler(req: Request) {
+            assert!(!req.is_xhr);
+        }
+        let app = Router::new().route("/test", get(handler));
+        let (_, addr) = spawn_test_app(app).await;
 
         let client = reqwest::Client::new();
 
         let res = client
-            .get(format!("http://{}/expect_inertia", &addr))
-            .header("X-Inertia", "true")
-            .header("X-Inertia-Version", "required")
-            .send()
-            .await
-            .unwrap();
-        assert_eq!(res.status(), StatusCode::OK);
-
-        let res = client
-            .get(format!("http://{}/expect_not_inertia", &addr))
+            .get(format!("http://{}/test", &addr))
             .header("X-Inertia", "false")
-            .header("X-Inertia-Version", "not-required")
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn it_extracts_a_version_string() {
+        async fn handler(req: Request) {
+            assert_eq!(req.version, Some("version".to_string()));
+        }
+        let app = Router::new().route("/test", get(handler));
+        let (_, addr) = spawn_test_app(app).await;
+
+        let client = reqwest::Client::new();
+
+        let res = client
+            .get(format!("http://{}/test", &addr))
+            .header("X-Inertia-Version", "version")
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn it_works_with_no_version() {
+        async fn handler(req: Request) {
+            assert_eq!(req.version, None);
+        }
+        let app = Router::new().route("/test", get(handler));
+        let (_, addr) = spawn_test_app(app).await;
+
+        let client = reqwest::Client::new();
+
+        let res = client
+            .get(format!("http://{}/test", &addr))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn it_extracts_partial_data() {
+        async fn handler(req: Request) {
+            assert!(req.partial.is_some());
+            let partial = req.partial.unwrap();
+            assert_eq!(partial.props, vec!("one".to_string(), "two".to_string()));
+            assert_eq!(partial.component, "PartialComponent");
+        }
+        let app = Router::new().route("/test", get(handler));
+        let (_, addr) = spawn_test_app(app).await;
+
+        let client = reqwest::Client::new();
+
+        let res = client
+            .get(format!("http://{}/test", &addr))
+            .header("X-Inertia", "true")
+            .header("X-Inertia-Partial-Component", "PartialComponent")
+            .header("X-Inertia-Partial-Data", "one,two")
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn it_does_not_extract_partial_data_when_missing_headers() {
+        async fn handler(req: Request) {
+            assert!(req.partial.is_none());
+        }
+        let app = Router::new().route("/test", get(handler));
+        let (_, addr) = spawn_test_app(app).await;
+
+        let client = reqwest::Client::new();
+
+        let res = client
+            .get(format!("http://{}/test", &addr))
+            .header("X-Inertia", "true")
+            .header("X-Inertia-Partial-Data", "one,two")
             .send()
             .await
             .unwrap();
         assert_eq!(res.status(), StatusCode::OK);
 
         let res = client
-            .get(format!("http://{}/expect_no_version", &addr))
+            .get(format!("http://{}/test", &addr))
+            .header("X-Inertia", "true")
+            .header("X-Inertia-Partial-Component", "PartialComponent")
             .send()
             .await
             .unwrap();


### PR DESCRIPTION
Somewhat work in progress; no useful implementation/derive macro of
`Props` is provided yet. The idea is that objects that implement
`Props` know how to serialize themselves to json and are passed
information about "partial" Inertia reloads to exclude certain fields.