### PR TITLE
Fix/encryption & component to be dynamic

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,11 +190,11 @@ impl Inertia {
     }
 
     /// Renders an Inertia response.
-    pub fn render<S: Props>(self, component: &'static str, props: S) -> Response {
+    pub fn render<S: Props, C: ToString>(self, component: C, props: S) -> Response {
         let request = self.request;
         let url = request.url.clone();
         let page = Page {
-            component,
+            component: component.to_string(),
             props: props
                 .serialize(request.partial.as_ref())
                 // TODO: error handling

--- a/src/page.rs
+++ b/src/page.rs
@@ -9,7 +9,7 @@ use serde_json::Value;
 /// More info at: https://inertiajs.com/the-protocol#the-page-object
 #[derive(Serialize)]
 pub(crate) struct Page {
-    pub(crate) component: &'static str,
+    pub(crate) component: String,
     pub(crate) props: Value,
     pub(crate) url: String,
     pub(crate) version: Option<String>,

--- a/src/response.rs
+++ b/src/response.rs
@@ -43,7 +43,7 @@ mod tests {
             ..Request::test_request()
         };
         let page = Page {
-            component: "Testing",
+            component: "Testing".into(),
             props: serde_json::json!({ "test": "test" }),
             url: "/test".to_string(),
             version: None,


### PR DESCRIPTION
Hello, i had 2 issues from this projects that can be fixed in this PR.

1. Encryption in dev project: My vite proxy is under a https so i cant access to the serve page that inertia give me.
2. Pass `Page.component` from `&'static str` to `String`: In my axum app i have somes component names that need to be dynamic and served with `render` but i couldnt find a way to transform a `String` or `&str` that lived outside the render function.


Also no beaking changes in this PR.