### PR TITLE
vite: add missing !doctype tag

### DIFF
--- a/src/vite.rs
+++ b/src/vite.rs
@@ -124,8 +124,8 @@ impl Development {
                 None
             };
             html! {
+                (DOCTYPE)
                 html lang=(self.lang) {
-                    (DOCTYPE)
                     head {
                         title { (self.title) }
                         meta charset="utf-8";
@@ -230,6 +230,7 @@ impl Production {
             let main_integrity = self.main.integrity.clone();
 
             html! {
+                (DOCTYPE)
                 html lang=(self.lang) {
                     head {
                         title { (self.title) }
@@ -415,6 +416,7 @@ mod tests {
         let binding = config_layout(r#"{"someprops": "somevalues"}"#.to_string());
         let rendered_layout = binding.as_str();
 
+        assert!(rendered_layout.contains(r#"<!DOCTYPE html>"#));
         assert!(rendered_layout
             .contains(r#"<script type="module" src="/main.hash-id-here.js"></script>"#));
         assert!(rendered_layout.contains(r#"<link rel="stylesheet" href="/style.css"/>"#));

--- a/src/vite.rs
+++ b/src/vite.rs
@@ -29,7 +29,7 @@
 //! [vitejs]: https://vitejs.dev
 use crate::config::InertiaConfig;
 use hex::encode;
-use maud::{html, PreEscaped};
+use maud::{html, PreEscaped, DOCTYPE};
 use serde::Deserialize;
 use sha1::{Digest, Sha1};
 use std::collections::HashMap;
@@ -125,6 +125,7 @@ impl Development {
             };
             html! {
                 html lang=(self.lang) {
+                    (DOCTYPE)
                     head {
                         title { (self.title) }
                         meta charset="utf-8";
@@ -350,6 +351,7 @@ mod tests {
         let binding = config_layout(r#"{"someprops": "somevalues"}"#.to_string());
         let rendered_layout = binding.as_str();
 
+        assert!(rendered_layout.contains(r#"<!DOCTYPE html>"#));
         assert!(rendered_layout.contains(r#"<html lang="lang-id">"#));
         assert!(rendered_layout.contains(r#"<title>app-title-here</title>"#));
         assert!(rendered_layout.contains(r#"{&quot;someprops&quot;: &quot;somevalues&quot;}"#));


### PR DESCRIPTION
In our app we currently have this warning on firefox, so because it is a standard i added directly in the html template.
![image](https://github.com/user-attachments/assets/21ab6b2b-1abd-461e-a024-a34c9d58eb3c)

But for others scripts tag or things that we want to append in the base html template we cannot with the current interface provided by axum_inertia.
For now i dont have a solution but i can work on that in the the next weeks/months when i have time.