### PR TITLE
chore: upgrade axum to `0.8.1`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,17 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
-name = "async-trait"
-version = "0.1.74"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.38",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -36,13 +25,13 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axum"
-version = "0.7.5"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a6c9af12842a67734c9a2e355436e5d03b22383ed60cf13cd0c18fbfe3dcbcf"
+checksum = "6d6fd624c75e18b3b4c6b9caf42b1afe24437daaee904069137d8bab077be8b8"
 dependencies = [
- "async-trait",
  "axum-core",
  "bytes",
+ "form_urlencoded",
  "futures-util",
  "http 1.0.0",
  "http-body 1.0.0",
@@ -60,9 +49,9 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sync_wrapper 1.0.1",
+ "sync_wrapper",
  "tokio",
- "tower",
+ "tower 0.5.2",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -70,11 +59,10 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.4.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a15c63fd72d41492dc4f497196f5da1fb04fb7529e631d73630d1b491e47a2e3"
+checksum = "df1362f362fd16024ae199c1970ce98f9661bf5ef94b9808fee734bc3698b733"
 dependencies = [
- "async-trait",
  "bytes",
  "futures-util",
  "http 1.0.0",
@@ -83,7 +71,7 @@ dependencies = [
  "mime",
  "pin-project-lite",
  "rustversion",
- "sync_wrapper 0.1.2",
+ "sync_wrapper",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -93,7 +81,6 @@ dependencies = [
 name = "axum-inertia"
 version = "0.7.0"
 dependencies = [
- "async-trait",
  "axum",
  "hex",
  "http 1.0.0",
@@ -513,6 +500,8 @@ dependencies = [
  "hyper 1.3.1",
  "pin-project-lite",
  "tokio",
+ "tower 0.4.13",
+ "tower-service",
 ]
 
 [[package]]
@@ -598,9 +587,9 @@ checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "matchit"
-version = "0.7.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "maud"
@@ -1100,12 +1089,6 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
-
-[[package]]
-name = "sync_wrapper"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
@@ -1226,6 +1209,21 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
  "tracing",
 ]
 
@@ -1249,15 +1247,15 @@ dependencies = [
 
 [[package]]
 name = "tower-layer"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-service"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT OR Apache-2.0"
 description = "An implementation of the Inertia.js protocol for Axum"
 repository = "https://github.com/mjhoy/axum-inertia"
 keywords = ["axum", "inertia"]
+rust-version = "1.75"
 
 [dependencies]
 axum = "0.8.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,7 @@ repository = "https://github.com/mjhoy/axum-inertia"
 keywords = ["axum", "inertia"]
 
 [dependencies]
-axum = "0.7.5"
-async-trait = "0.1.74"
+axum = "0.8.1"
 http = "1.0.0"
 hyper = "1.0.1"
 serde = { version = "1.0.189", features = ["derive"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,7 +137,6 @@
 //! [axum]: https://crates.io/crates/axum
 //! [Extractor]: https://docs.rs/axum/latest/axum/#extractors
 
-use async_trait::async_trait;
 use axum::extract::{FromRef, FromRequestParts};
 pub use config::InertiaConfig;
 use http::{request::Parts, HeaderMap, HeaderValue, StatusCode};
@@ -160,7 +159,6 @@ pub struct Inertia {
     config: InertiaConfig,
 }
 
-#[async_trait]
 impl<S> FromRequestParts<S> for Inertia
 where
     S: Send + Sync,

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,5 +1,4 @@
 use crate::partial::Partial;
-use async_trait::async_trait;
 use axum::extract::{FromRequestParts, OriginalUri};
 use http::{request::Parts, HeaderMap, HeaderValue, StatusCode};
 
@@ -27,7 +26,6 @@ impl Request {
     }
 }
 
-#[async_trait]
 impl<S> FromRequestParts<S> for Request
 where
     S: Send + Sync,


### PR DESCRIPTION
When i upgraded axum to `0.8` axum_inertia causes error when it comes to render so i upgraded and tested in my own branch and everything is fine.
Also i removed `async-trait` because its no longer necessary in `0.8`.