### PR TITLE
update dependabot versioning strategy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,4 @@ updates:
     directory: /
     schedule:
       interval: daily
+    versioning-strategy: increase-if-necessary


### PR DESCRIPTION
Let's try this setting. I want in general for it to only update the lockfile
when necessary because this is a library.