### PR TITLE
change dependabot versioning to `lockfile-only`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,4 +8,4 @@ updates:
     directory: /
     schedule:
       interval: daily
-    versioning-strategy: increase-if-necessary
+    versioning-strategy: lockfile-only


### PR DESCRIPTION
Looks like the cargo ecosystem doesn't support `increase-if-necessary`: https://github.com/dependabot/dependabot-core/issues/4009