### PR TITLE
add `Vary` header for xhr requests

### DIFF
--- a/src/response.rs
+++ b/src/response.rs
@@ -21,6 +21,7 @@ impl IntoResponse for Response<'_> {
         }
         if self.request.is_xhr {
             headers.insert("X-Inertia", "true".parse().unwrap());
+            headers.insert("Vary", "X-Inertia".parse().unwrap());
             (headers, Json(self.page)).into_response()
         } else {
             let html = (self.config.layout())(serde_json::to_string(&self.page).unwrap());


### PR DESCRIPTION
Fixes #78

This header helps the browser avoid reusing the server's xhr responses when
e.g. duplicating a tab and requiring HTML sent back.

Thanks @redzic for the bug report.