### PR TITLE
dev fix: update rustfmt edition

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,1 @@
-edition = "2024"
+edition = "2021"


### PR DESCRIPTION
I added the wrong edition for `rustfmt.toml` which explains why I was getting
different outputs from my lsp vs `cargo fmt`.