### PR TITLE
Fix lifetime elided warning

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -193,7 +193,7 @@ impl Inertia {
     }
 
     /// Renders an Inertia response.
-    pub fn render<S: Props>(self, component: &str, props: S) -> Response {
+    pub fn render<S: Props>(self, component: &str, props: S) -> Response<'_> {
         let request = self.request;
         let url = request.url.clone();
         let page = Page {


### PR DESCRIPTION
Fixes the "the same lifetime is referred to in inconsistent ways, making the
signature confusing" warning from the latest rust version.